### PR TITLE
Use the stable psf/black github action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           python-version-file: '.python-version'
       - uses: isort/isort-action@v1
-      - uses: psf/black@20.8b1
+      - uses: psf/black@stable
 


### PR DESCRIPTION
Change the psf/black action to use `stable` instead of a pinned version