### PR TITLE
Switch to using pipx

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,8 @@ function install_dependencies {
 			if ! which autossh; then
 				sudo apt-get -y update && sudo apt-get install -y autossh
 			fi
-			if ! which pip3; then
-				sudo apt-get -y update && sudo apt-get install -y python3-pip
+			if ! which pipx; then
+				sudo apt-get -y update && sudo apt-get install -y pipx
 			fi
 			if ! which whois; then
 				sudo apt-get -y update && sudo apt-get install -y whois
@@ -32,6 +32,9 @@ function install_dependencies {
 			fi
 			if [ "$(which python3)" != "/usr/local/bin/python3" ]; then
 				brew install python
+			fi
+			if ! which pipx; then
+			    brew install pipx
 			fi
 			if ! which whois; then
 				brew install whois
@@ -65,7 +68,7 @@ function install {
 	fi
 
 	curl -LJO $DOWNLOAD_URL
-	pip3 install --force-reinstall ./"$FILENAME"
+	pipx install --force ./"$FILENAME"
 	rm "$FILENAME"
 }
 

--- a/oo_bin/main.py
+++ b/oo_bin/main.py
@@ -33,12 +33,19 @@ colorama.init(autoreset=True)
 
 @click.group(invoke_without_command=True)
 @click.version_option(__version__)
-@click.option("-u", "--update", is_flag=True, help="Update tunnels package")
+@click.option("-u", "--update", is_flag=True, help="Update")
+@click.option(
+    "-t",
+    "--update-tag",
+    is_flag=True,
+    help="Update to a specific release",
+    Default=False,
+)
 @click.pass_context
-def cli(ctx, update):
+def cli(ctx, update, updateTag):
     if update:
         update_tunnels_config()
-        update_package()
+        update_package(updateTag)
         return
 
     if not ctx.invoked_subcommand:

--- a/oo_bin/main.py
+++ b/oo_bin/main.py
@@ -34,18 +34,12 @@ colorama.init(autoreset=True)
 @click.group(invoke_without_command=True)
 @click.version_option(__version__)
 @click.option("-u", "--update", is_flag=True, help="Update")
-@click.option(
-    "-t",
-    "--update-tag",
-    is_flag=True,
-    help="Update to a specific release",
-    Default=False,
-)
+@click.option("-t", "--update-tag", help="Update to a specific release", default="")
 @click.pass_context
-def cli(ctx, update, updateTag):
-    if update:
+def cli(ctx, update, update_tag):
+    if update or update_tag != "":
         update_tunnels_config()
-        update_package(updateTag)
+        update_package(update_tag)
         return
 
     if not ctx.invoked_subcommand:

--- a/oo_bin/utils.py
+++ b/oo_bin/utils.py
@@ -102,7 +102,7 @@ def __latest_release_info():
 
 def __release_info(tag):
     with requests.get(
-        "https://api.github.com/repos/outsideopen/oo-bin-py/releases/latest"
+        "https://api.github.com/repos/outsideopen/oo-bin-py/releases"
     ) as r:
         r.raise_for_status()
         response = r.json()
@@ -126,8 +126,8 @@ def __download_package(url):
     return tmp_file
 
 
-def update_package(tag=False):
-    if tag is False:
+def update_package(tag=""):
+    if tag == "":
         release_info = __latest_release_info()
         tag = release_info.get("tag_name")
     else:

--- a/oo_bin/utils.py
+++ b/oo_bin/utils.py
@@ -142,7 +142,7 @@ def update_package():
 
             tmp_file = __download_package(download_url)
 
-            cmd = ["pip3", "install", "--force-reinstall", str(tmp_file)]
+            cmd = ["pipx", "install", "--force", str(tmp_file)]
             subprocess.run(cmd)
 
 

--- a/oo_bin/utils.py
+++ b/oo_bin/utils.py
@@ -100,6 +100,19 @@ def __latest_release_info():
         return response
 
 
+def __release_info(tag):
+    with requests.get(
+        "https://api.github.com/repos/outsideopen/oo-bin-py/releases/latest"
+    ) as r:
+        r.raise_for_status()
+        response = r.json()
+        for release in response:
+            if release["tag_name"] == tag:
+                return release
+
+        return False
+
+
 def __download_package(url):
     tmp_dir = tempfile.mkdtemp(dir=tempfile.gettempdir())
     tmp_file = Path(tmp_dir).joinpath(Path(url).name)
@@ -113,10 +126,15 @@ def __download_package(url):
     return tmp_file
 
 
-def update_package():
-    release_info = __latest_release_info()
-
-    tag = release_info.get("tag_name")
+def update_package(tag=False):
+    if tag is False:
+        release_info = __latest_release_info()
+        tag = release_info.get("tag_name")
+    else:
+        release_info = __release_info(tag)
+        if release_info is False:
+            print(f"No release info for {tag}")
+            sys.exit(1)
 
     if __version__ == "0.0.0":
         print("Updates are not supported on development versions of the project.")


### PR DESCRIPTION
Due to [PEP 668](https://peps.python.org/pep-0668/) all modern python installations via apt and brew set the externally-managed-environment and recommend switching to pipx.

This changes our usage of `pip3` to `pipx` along with updated install parameters.