### PR TITLE
Use the ssh_config when using `oo ssh`

### DIFF
--- a/oo_bin/ssh/__init__.py
+++ b/oo_bin/ssh/__init__.py
@@ -2,7 +2,12 @@ import os
 
 from click.shell_completion import CompletionItem
 
-from oo_bin.config import main_config, ssh_config_path, tunnels_config, tunnels_config_path
+from oo_bin.config import (
+    main_config,
+    ssh_config_path,
+    tunnels_config,
+    tunnels_config_path,
+)
 from oo_bin.errors import OOBinError
 
 

--- a/oo_bin/ssh/__init__.py
+++ b/oo_bin/ssh/__init__.py
@@ -38,7 +38,7 @@ class Ssh:
             )
 
         ssh_config = main_config().get("tunnels", {}).get("ssh_config", ssh_config_path)
-        
+
         if host:
             cmd = ["ssh", "-F", ssh_config, "-J", jump_host, "-p", ssh_port, ssh_host]
         else:

--- a/oo_bin/ssh/__init__.py
+++ b/oo_bin/ssh/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from click.shell_completion import CompletionItem
 
-from oo_bin.config import main_config, tunnels_config, tunnels_config_path
+from oo_bin.config import main_config, ssh_config_path, tunnels_config, tunnels_config_path
 from oo_bin.errors import OOBinError
 
 

--- a/oo_bin/ssh/__init__.py
+++ b/oo_bin/ssh/__init__.py
@@ -32,10 +32,12 @@ class Ssh:
                 f"Jump host not defined in configuration. Update {tunnels_config_path}"
             )
 
+        ssh_config = main_config().get("tunnels", {}).get("ssh_config", ssh_config_path)
+        
         if host:
-            cmd = ["ssh", "-J", jump_host, "-p", ssh_port, ssh_host]
+            cmd = ["ssh", "-F", ssh_config, "-J", jump_host, "-p", ssh_port, ssh_host]
         else:
-            cmd = ["ssh", jump_host]
+            cmd = ["ssh", "-F", ssh_config, jump_host]
 
         os.spawnvpe(os.P_WAIT, "ssh", cmd, os.environ)
         return cmd

--- a/oo_bin/ssh/__init__.py
+++ b/oo_bin/ssh/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from click.shell_completion import CompletionItem
 
-from oo_bin.config import tunnels_config, tunnels_config_path
+from oo_bin.config import main_config, tunnels_config, tunnels_config_path
 from oo_bin.errors import OOBinError
 
 

--- a/tests/oo_bin/ssh/test_ssh.py
+++ b/tests/oo_bin/ssh/test_ssh.py
@@ -15,16 +15,43 @@ class TestSsh:
         mocker.patch("os.spawnvpe", return_value=True)
         ssh = Ssh()
 
-        ssh_config_path = '/home/runner/.config/oo_bin/ssh_config'
-        
+        ssh_config_path = "/home/runner/.config/oo_bin/ssh_config"
+
         command = ssh.connect("foo")
         assert command == ["ssh", "-F", ssh_config_path, "foo.example.com"]
 
         command2 = ssh.connect("foo", "second_ssh")
-        assert command2 == ["ssh", "-F", ssh_config_path, "-J", "foo.example.com", "-p", "2222", "192.168.2.2"]
+        assert command2 == [
+            "ssh",
+            "-F",
+            ssh_config_path,
+            "-J",
+            "foo.example.com",
+            "-p",
+            "2222",
+            "192.168.2.2",
+        ]
 
         command3 = ssh.connect("foo", "192.168.3.1")
-        assert command3 == ["ssh", "-F", ssh_config_path, "-J", "foo.example.com", "-p", "22", "192.168.3.1"]
+        assert command3 == [
+            "ssh",
+            "-F",
+            ssh_config_path,
+            "-J",
+            "foo.example.com",
+            "-p",
+            "22",
+            "192.168.3.1",
+        ]
 
         command4 = ssh.connect("foo", "192.168.3.1:2323")
-        assert command4 == ["ssh", "-F", ssh_config_path, "-J", "foo.example.com", "-p", "2323", "192.168.3.1"]
+        assert command4 == [
+            "ssh",
+            "-F",
+            ssh_config_path,
+            "-J",
+            "foo.example.com",
+            "-p",
+            "2323",
+            "192.168.3.1",
+        ]

--- a/tests/oo_bin/ssh/test_ssh.py
+++ b/tests/oo_bin/ssh/test_ssh.py
@@ -15,14 +15,16 @@ class TestSsh:
         mocker.patch("os.spawnvpe", return_value=True)
         ssh = Ssh()
 
+        ssh_config_path = '/home/runner/.config/oo_bin/ssh_config'
+        
         command = ssh.connect("foo")
-        assert command == ["ssh", "foo.example.com"]
+        assert command == ["ssh", "-F", ssh_config_path, "foo.example.com"]
 
         command2 = ssh.connect("foo", "second_ssh")
-        assert command2 == ["ssh", "-J", "foo.example.com", "-p", "2222", "192.168.2.2"]
+        assert command2 == ["ssh", "-F", ssh_config_path, "-J", "foo.example.com", "-p", "2222", "192.168.2.2"]
 
         command3 = ssh.connect("foo", "192.168.3.1")
-        assert command3 == ["ssh", "-J", "foo.example.com", "-p", "22", "192.168.3.1"]
+        assert command3 == ["ssh", "-F", ssh_config_path, "-J", "foo.example.com", "-p", "22", "192.168.3.1"]
 
         command4 = ssh.connect("foo", "192.168.3.1:2323")
-        assert command4 == ["ssh", "-J", "foo.example.com", "-p", "2323", "192.168.3.1"]
+        assert command4 == ["ssh", "-F", ssh_config_path, "-J", "foo.example.com", "-p", "2323", "192.168.3.1"]


### PR DESCRIPTION
Currently, the ssh_config is not used when running `oo ssh` but it is when running `oo tunnels`, this brings this in to parity with that.