### PR TITLE
dnsme: Check for `expiration_date` instead of `status`

### DIFF
--- a/oo_bin/dnsme/__init__.py
+++ b/oo_bin/dnsme/__init__.py
@@ -32,7 +32,7 @@ class Dnsme:
         if not shutil.which("whois"):
             raise DependencyNotMetError("whois is not installed, or is not in the path")
 
-        if not self.__whois or not self.__whois.status:
+        if not self.__whois or not self.__whois.expiration_date:
             raise DomainNotExistError(f"The domain {self.domain} does not exist")
 
         self.a = None


### PR DESCRIPTION
The EDU registrar didn't have a `status` but had an `expiration_date`